### PR TITLE
dynamicPageFindMethodAdvice: omit findChild and findChildren

### DIFF
--- a/dist/rules/dynamicPageFindMethodAdvice.js
+++ b/dist/rules/dynamicPageFindMethodAdvice.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.dynamicPageFindMethodAdvice = void 0;
 const typescript_estree_1 = require("@typescript-eslint/typescript-estree");
 const util_1 = require("../util");
-const findMethods = ['findAll', 'findAllWithCriteria', 'findChild', 'findChildren', 'findOne'];
+const findMethods = ['findAll', 'findAllWithCriteria', 'findOne'];
 exports.dynamicPageFindMethodAdvice = (0, util_1.createPluginRule)({
     name: 'dynamic-page-find-method-advice',
     meta: {

--- a/src/rules/dynamicPageFindMethodAdvice.ts
+++ b/src/rules/dynamicPageFindMethodAdvice.ts
@@ -5,7 +5,7 @@ import { createPluginRule, matchAncestorTypes } from '../util'
 // This is a TypeScript bug; cf https://github.com/microsoft/TypeScript/issues/47663
 import type { TSESLint as _ } from '@typescript-eslint/utils'
 
-const findMethods = ['findAll', 'findAllWithCriteria', 'findChild', 'findChildren', 'findOne']
+const findMethods = ['findAll', 'findAllWithCriteria', 'findOne']
 
 export const dynamicPageFindMethodAdvice = createPluginRule({
   name: 'dynamic-page-find-method-advice',


### PR DESCRIPTION
To be merged after internal b097d9d is deployed, ETA 2024.02.07.