### PR TITLE
rename rules for GA

### DIFF
--- a/.eslint-doc-generatorrc.json
+++ b/.eslint-doc-generatorrc.json
@@ -1,6 +1,6 @@
 {
   "configEmoji": [
-    ["dynamic-page", "⚡"],
-    ["dynamic-page-problems-only", "💥"]
+    ["recommended", "👍"],
+    ["recommended-problems-only", "🔦"]
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,3 +3,75 @@
 If you notice any problems with this linter, please [file an issue](https://github.com/figma/rest-api-spec/issues). We welcome PRs!
 
 For bug reports and feature requests for Figma or the Figma Plugin API itself, please [contact Figma support](https://help.figma.com/hc/en-us/requests/new).
+
+## Local development
+
+## Building the package
+
+To rebuild both the lint plugin and documentation:
+
+```
+npm run build
+```
+
+To rebuild the lint plugin when source files change:
+
+```
+npm run watch
+```
+
+Any consuming repo will need to re-install the package using the process described [above](#install-the-package).
+
+### Documentation
+
+This plugin uses [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator) to produce docs for each rule, as well as parts of the [README](./README.md).
+
+To automatically re-build documentation for rules:
+
+```
+npm run update:eslint-docs
+```
+
+### Tests
+
+Tests are implemented in the [test/](./test) directory using [@typescript-eslint/RuleTester](https://typescript-eslint.io/packages/rule-tester/). The test harness is [ts-jest]().
+
+To run tests, run:
+
+```
+npm run tests
+```
+
+To run an invidual test, you can run Jest with the `-t` parameter, followed by the string handle for the test. The handle is declared in each test file. Example:
+
+```
+npx jest -t 'await-requires-async'
+```
+
+Jest has an issue with printing errors emitted from eslint rules [due to a bug](https://github.com/jestjs/jest/issues/10577). If you are seeing errors like `TypeError: Converting circular structure to JSON`, then run this instead:
+
+```
+npm run test-workaround
+```
+
+This enables the `--detect-open-handles` Jest option. Tests will run slower, but you'll see the real cause of the errors.
+
+### Manual testing
+
+You may want to run a local version of this plugin against your own plugin code.
+
+First, clone this repo. Then add the following to your Figma plugin's `package.json`, replacing `/path/to/local/clone` with an actual filesystem path:
+
+```
+{
+  ...
+  "devDependencies": {
+    "@figma/eslint-plugin-figma-plugins": "file:/path/to/local/clone",
+    ...
+  }
+}
+```
+
+#### Update node_modules
+
+Once you've updated your `package.json`, run `npm install` to pull down the latest changes.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,9 @@ This repository defines [typescript-eslint](https://typescript-eslint.io/) rules
 
 This linter is still in beta, and may include lint warnings about features that aren't generally available. Please avoid using it unless you've been advised to do so. We appreciate your patience!
 
-### Why the weird, repetitive name?
+## Installation
 
-ESLint package names must start with `eslint-plugin-`. Under this convention, the shortest name we could use is probably `@figma/eslint-plugin-plugins`, but that's pretty confusing! So the current name is a compromise between clarity and brevity.
-
-## Usage
-
-### Installation
-
-#### Dependencies
+### Dependencies
 
 This linter requires TypeScript, ESLint, typescript-eslint, and the Figma Plugin API type definitions. To install all of these, run:
 
@@ -20,47 +14,17 @@ This linter requires TypeScript, ESLint, typescript-eslint, and the Figma Plugin
 npm install -D typescript eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin @figma/plugin-typings
 ```
 
-#### Install the ESLint plugin package
-
-This package has not yet been published to NPM. You can get it in two ways:
-
-##### Directly via git
-
-Add the following to your Figma plugin's `package.json`:
+### Install the ESLint plugin package
 
 ```
-{
-  ...
-  "devDependencies": {
-    "@figma/eslint-plugin-figma-plugins": "git://github.com/figma/eslint-plugin-figma-plugins",
-    ...
-  }
-}
+npm install -D @figma/eslint-plugin-figma-plugins
 ```
 
-##### From local disk
-
-Clone this repo. Then add the following to your Figma plugin's `package.json`, replacing `/path/to/local/clone` with an actual filesystem path:
-
-```
-{
-  ...
-  "devDependencies": {
-    "@figma/eslint-plugin-figma-plugins": "file:/path/to/local/clone",
-    ...
-  }
-}
-```
-
-#### Update node_modules
-
-Once you've updated your `package.json`, run `npm install` to pull down the latest changes.
-
-#### Configure eslint
+### Configure eslint
 
 If you haven't already, install ESLint. We recommend installing it alongside typescript-eslint using [these instructions](https://typescript-eslint.io/getting-started#step-1-installation).
 
-Update your ESLint config's `extends` array to include the `plugin:@figma/figma-plugins/dynamic-page` ruleset. We also recommend the following rulesets:
+Update your ESLint config's `extends` array to include the `plugin:@figma/figma-plugins/recommended` ruleset. We also recommend the following rulesets:
 
 - `eslint:recommended`,
 - `plugin:@typescript-eslint/recommended-type-checked`
@@ -88,7 +52,7 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended-type-checked',
     'plugin:@typescript-eslint/stylistic-type-checked',
-    'plugin:@figma/figma-plugins/dynamic-page',
+    'plugin:@figma/figma-plugins/recommended',
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
@@ -98,9 +62,11 @@ module.exports = {
 }
 ```
 
-#### Restart the ESLint server
+### Restart the ESLint server
 
 If you've run `npm install` and updated to a newer version of this package, remember to restart your IDE. In VSCode, you can restart the ESLint server independently by opening the command palette and choosing "Restart ESLint Server".
+
+## Usage
 
 ### Linting and autofixing
 
@@ -128,58 +94,22 @@ To use ESLint with VSCode, see the [ESLint VSCode extension](https://marketplace
 
 💼 Configurations enabled in.\
 ⚠️ Configurations set to warn in.\
-⚡ Set in the `dynamic-page` configuration.\
-💥 Set in the `dynamic-page-problems-only` configuration.\
+👍 Set in the `recommended` configuration.\
+🔦 Set in the `recommended-problems-only` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                                                               | Description                                                                  | 💼   | ⚠️ | 🔧 |
-| :------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------- | :--- | :- | :- |
-| [await-requires-async](docs/rules/await-requires-async.md)                                         | Require functions that contain `await` to be `async`                         | ⚡ 💥 |    | 🔧 |
-| [dynamic-page-ban-id-params](docs/rules/dynamic-page-ban-id-params.md)                             | Ban string ID parameters that are not compatible with `dynamic-page`         | ⚡ 💥 |    | 🔧 |
-| [dynamic-page-ban-style-setters-temp](docs/rules/dynamic-page-ban-style-setters-temp.md)           | Ban `async` style-assignment methods from the `dynamic-page` beta            | ⚡ 💥 |    | 🔧 |
-| [dynamic-page-ban-sync-methods](docs/rules/dynamic-page-ban-sync-methods.md)                       | Ban synchronous methods that are not compatible with `dynamic-page`          | ⚡ 💥 |    | 🔧 |
-| [dynamic-page-ban-sync-prop-getters](docs/rules/dynamic-page-ban-sync-prop-getters.md)             | Ban synchronous property getters that are not compatible with `dynamic-page` | ⚡ 💥 |    | 🔧 |
-| [dynamic-page-ban-sync-prop-setters](docs/rules/dynamic-page-ban-sync-prop-setters.md)             | Ban synchronous property getters that are not compatible with `dynamic-page` | ⚡ 💥 |    | 🔧 |
-| [dynamic-page-documentchange-event-advice](docs/rules/dynamic-page-documentchange-event-advice.md) | Advice on using the `documentchange` event                                   |      | ⚡  |    |
-| [dynamic-page-find-method-advice](docs/rules/dynamic-page-find-method-advice.md)                   | Advice on using the find*() family of methods                                |      | ⚡  |    |
+| Name                                                                                               | Description                                                                  | 💼    | ⚠️ | 🔧 |
+| :------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------- | :---- | :- | :- |
+| [await-requires-async](docs/rules/await-requires-async.md)                                         | Require functions that contain `await` to be `async`                         | 👍 🔦 |    | 🔧 |
+| [dynamic-page-ban-id-params](docs/rules/dynamic-page-ban-id-params.md)                             | Ban string ID parameters that are not compatible with `dynamic-page`         | 👍 🔦 |    | 🔧 |
+| [dynamic-page-ban-style-setters-temp](docs/rules/dynamic-page-ban-style-setters-temp.md)           | Ban `async` style-assignment methods from the `dynamic-page` beta            | 👍 🔦 |    | 🔧 |
+| [dynamic-page-ban-sync-methods](docs/rules/dynamic-page-ban-sync-methods.md)                       | Ban synchronous methods that are not compatible with `dynamic-page`          | 👍 🔦 |    | 🔧 |
+| [dynamic-page-ban-sync-prop-getters](docs/rules/dynamic-page-ban-sync-prop-getters.md)             | Ban synchronous property getters that are not compatible with `dynamic-page` | 👍 🔦 |    | 🔧 |
+| [dynamic-page-ban-sync-prop-setters](docs/rules/dynamic-page-ban-sync-prop-setters.md)             | Ban synchronous property getters that are not compatible with `dynamic-page` | 👍 🔦 |    | 🔧 |
+| [dynamic-page-documentchange-event-advice](docs/rules/dynamic-page-documentchange-event-advice.md) | Advice on using the `documentchange` event                                   |       | 👍 |    |
+| [dynamic-page-find-method-advice](docs/rules/dynamic-page-find-method-advice.md)                   | Advice on using the find*() family of methods                                |       | 👍 |    |
 
 <!-- end auto-generated rules list -->
-
-## Developing
-
-### Building the package
-
-To compile the rules into a consumable ESLint plugin, run:
-
-```
-npm run watch
-```
-
-Any consuming repo will need to re-install the package using the process described [above](#install-the-package).
-
-### Tests
-
-Tests are implemented in the [test/](./test) directory using [@typescript-eslint/RuleTester](https://typescript-eslint.io/packages/rule-tester/). The test harness is [ts-jest]().
-
-To run tests, run:
-
-```
-npm run tests
-```
-
-To run an invidual test, you can run Jest with the `-t` parameter, followed by the string handle for the test. The handle is declared in each test file. Example:
-
-```
-npx jest -t 'await-requires-async'
-```
-
-Jest has an issue with printing errors emitted from eslint rules [due to a bug](https://github.com/jestjs/jest/issues/10577). If you are seeing errors like `TypeError: Converting circular structure to JSON`, then run this instead:
-
-```
-npm run test-workaround
-```
-
-This enables the `--detect-open-handles` Jest option. Tests will run slower, but you'll see the real cause of the errors.
 
 ### Contributing
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -33,11 +33,11 @@ const dynamicePageAdvice = {
 // declaration file.
 exports.rules = Object.assign(Object.assign({}, dynamicPageErrs), dynamicePageAdvice);
 exports.configs = {
-    'dynamic-page': {
+    recommended: {
         plugins: ['@figma/figma-plugins'],
         rules: Object.assign(Object.assign({}, rulesetWithSeverity('error', dynamicPageErrs)), rulesetWithSeverity('warn', dynamicePageAdvice)),
     },
-    'dynamic-page-problems-only': {
+    'recommended-problems-only': {
         plugins: ['@figma/figma-plugins'],
         rules: Object.assign({}, rulesetWithSeverity('error', dynamicPageErrs)),
     },

--- a/docs/rules/await-requires-async.md
+++ b/docs/rules/await-requires-async.md
@@ -1,6 +1,6 @@
 # Require functions that contain `await` to be `async` (`@figma/figma-plugins/await-requires-async`)
 
-💼 This rule is enabled in the following configs: ⚡ `dynamic-page`, 💥 `dynamic-page-problems-only`.
+💼 This rule is enabled in the following configs: 👍 `recommended`, 🔦 `recommended-problems-only`.
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/dynamic-page-ban-id-params.md
+++ b/docs/rules/dynamic-page-ban-id-params.md
@@ -1,6 +1,6 @@
 # Ban string ID parameters that are not compatible with `dynamic-page` (`@figma/figma-plugins/dynamic-page-ban-id-params`)
 
-💼 This rule is enabled in the following configs: ⚡ `dynamic-page`, 💥 `dynamic-page-problems-only`.
+💼 This rule is enabled in the following configs: 👍 `recommended`, 🔦 `recommended-problems-only`.
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/dynamic-page-ban-style-setters-temp.md
+++ b/docs/rules/dynamic-page-ban-style-setters-temp.md
@@ -1,6 +1,6 @@
 # Ban `async` style-assignment methods from the `dynamic-page` beta (`@figma/figma-plugins/dynamic-page-ban-style-setters-temp`)
 
-💼 This rule is enabled in the following configs: ⚡ `dynamic-page`, 💥 `dynamic-page-problems-only`.
+💼 This rule is enabled in the following configs: 👍 `recommended`, 🔦 `recommended-problems-only`.
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/dynamic-page-ban-sync-methods.md
+++ b/docs/rules/dynamic-page-ban-sync-methods.md
@@ -1,6 +1,6 @@
 # Ban synchronous methods that are not compatible with `dynamic-page` (`@figma/figma-plugins/dynamic-page-ban-sync-methods`)
 
-💼 This rule is enabled in the following configs: ⚡ `dynamic-page`, 💥 `dynamic-page-problems-only`.
+💼 This rule is enabled in the following configs: 👍 `recommended`, 🔦 `recommended-problems-only`.
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/dynamic-page-ban-sync-prop-getters.md
+++ b/docs/rules/dynamic-page-ban-sync-prop-getters.md
@@ -1,6 +1,6 @@
 # Ban synchronous property getters that are not compatible with `dynamic-page` (`@figma/figma-plugins/dynamic-page-ban-sync-prop-getters`)
 
-💼 This rule is enabled in the following configs: ⚡ `dynamic-page`, 💥 `dynamic-page-problems-only`.
+💼 This rule is enabled in the following configs: 👍 `recommended`, 🔦 `recommended-problems-only`.
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/dynamic-page-ban-sync-prop-setters.md
+++ b/docs/rules/dynamic-page-ban-sync-prop-setters.md
@@ -1,6 +1,6 @@
 # Ban synchronous property getters that are not compatible with `dynamic-page` (`@figma/figma-plugins/dynamic-page-ban-sync-prop-setters`)
 
-💼 This rule is enabled in the following configs: ⚡ `dynamic-page`, 💥 `dynamic-page-problems-only`.
+💼 This rule is enabled in the following configs: 👍 `recommended`, 🔦 `recommended-problems-only`.
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/dynamic-page-documentchange-event-advice.md
+++ b/docs/rules/dynamic-page-documentchange-event-advice.md
@@ -1,6 +1,6 @@
 # Advice on using the `documentchange` event (`@figma/figma-plugins/dynamic-page-documentchange-event-advice`)
 
-⚠️ This rule _warns_ in the ⚡ `dynamic-page` config.
+⚠️ This rule _warns_ in the 👍 `recommended` config.
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/dynamic-page-find-method-advice.md
+++ b/docs/rules/dynamic-page-find-method-advice.md
@@ -1,6 +1,6 @@
 # Advice on using the find*() family of methods (`@figma/figma-plugins/dynamic-page-find-method-advice`)
 
-⚠️ This rule _warns_ in the ⚡ `dynamic-page` config.
+⚠️ This rule _warns_ in the 👍 `recommended` config.
 
 <!-- end auto-generated rule header -->
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,14 +42,14 @@ export const rules: unknown = {
 }
 
 export const configs: unknown = {
-  'dynamic-page': {
+  recommended: {
     plugins: ['@figma/figma-plugins'],
     rules: {
       ...rulesetWithSeverity('error', dynamicPageErrs),
       ...rulesetWithSeverity('warn', dynamicePageAdvice),
     },
   },
-  'dynamic-page-problems-only': {
+  'recommended-problems-only': {
     plugins: ['@figma/figma-plugins'],
     rules: {
       ...rulesetWithSeverity('error', dynamicPageErrs),


### PR DESCRIPTION
This change renames the `dynamic-page` rules to `recommended`, in preparation for GA. It also moves some local development instructions from README to CONTRIBUTING.