### PR TITLE
banDeprecatedSyncPropGetters: do not ban usage in assignment expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- Updated `ban-deprecated-sync-prop-getters` rule to allow _assignment_ to properties. This allows for statements such as `instance.mainComponent = ...`.
+
+## 0.12.0
+
+- Initial published version

--- a/dist/rules/banDeprecatedSyncPropGetters.js
+++ b/dist/rules/banDeprecatedSyncPropGetters.js
@@ -37,6 +37,11 @@ exports.banDeprecatedSyncPropGetters = (0, util_1.createPluginRule)({
     create(context) {
         return {
             MemberExpression(node) {
+                // allow the expression to be used in an assignment
+                const parent = node.parent;
+                if (parent && parent.type === typescript_estree_1.AST_NODE_TYPES.AssignmentExpression && parent.left === node) {
+                    return;
+                }
                 const prop = node.property;
                 if (prop.type !== typescript_estree_1.AST_NODE_TYPES.Identifier) {
                     return;

--- a/src/rules/banDeprecatedSyncPropGetters.ts
+++ b/src/rules/banDeprecatedSyncPropGetters.ts
@@ -47,6 +47,12 @@ export const banDeprecatedSyncPropGetters = createPluginRule({
   create(context) {
     return {
       MemberExpression(node: TSESTree.MemberExpression) {
+        // allow the expression to be used in an assignment
+        const parent = node.parent
+        if (parent && parent.type === AST_NODE_TYPES.AssignmentExpression && parent.left === node) {
+          return
+        }
+
         const prop = node.property
         if (prop.type !== AST_NODE_TYPES.Identifier) {
           return

--- a/test/banDeprecatedSyncPropGetters.test.ts
+++ b/test/banDeprecatedSyncPropGetters.test.ts
@@ -27,6 +27,15 @@ function func(componentNode: ComponentNode) {
 }
 `,
     },
+    {
+      // assignment expressions should be safe
+      code: `
+${types}
+function func(node: InstanceNode, comp: ComponentNode) {
+  node.mainComponent = comp
+}
+`,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Updated `ban-deprecated-sync-prop-getters` rule to allow _assignment_ to properties. This allows for statements such as `instance.mainComponent = ...`.

Also, start tracking updates in a changelog.