### PR TITLE
build: specify the package files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Any changes that haven't been included in a published version will be listed here.
 
+- build: specify the package files
+
 ## 0.14.0
 
 - Added `node.reactions = ...` to the list of banned property setters under `ban-deprecated-sync-prop-setters`. Use `node.setReactionsAsync` instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ To run tests, run:
 npm run tests
 ```
 
-To run an invidual test, you can run Jest with the `-t` parameter, followed by the string handle for the test. The handle is declared in each test file. Example:
+To run an individual test, you can run Jest with the `-t` parameter, followed by the string handle for the test. The handle is declared in each test file. Example:
 
 ```
 npx jest -t 'await-requires-async'

--- a/package.json
+++ b/package.json
@@ -24,6 +24,13 @@
     "url": "https://github.com/figma/eslint-plugin-figma-plugins/issues"
   },
   "homepage": "https://github.com/figma/eslint-plugin-figma-plugins#readme",
+  "files": [
+    "dist/",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "README.md"
+  ],
   "dependencies": {
     "@typescript-eslint/typescript-estree": "^6.13.2",
     "@typescript-eslint/utils": "^6.12.0",


### PR DESCRIPTION
Currently, the npm package contains a lot of excessive files.

The only needed files there are the `dist` folder, `LICENSE`, and `README.md` files.

![Screenshot 2024-03-06 at 17 32 07](https://github.com/figma/eslint-plugin-figma-plugins/assets/29282228/29feeb47-0d56-4834-a5a9-22bfbdbd8c49)