### PR TITLE
package.json: add peer dependency for plugin-typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Any changes that haven't been included in a published version will be listed here.
 
+- package.json: ensure [@figma/plugin-typings](https://www.npmjs.com/package/@figma/plugin-typings) is listed as a peer dependency
+
 ## 0.15.0
 
 - package.json: restrict package files ([@andrii-bodnar](https://github.com/andrii-bodnar))

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,9 @@
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
         "tsx": "^4.6.2"
+      },
+      "peerDependencies": {
+        "@figma/plugin-typings": "1.87.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1100,6 +1103,12 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@figma/plugin-typings": {
+      "version": "1.87.0",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.87.0.tgz",
+      "integrity": "sha512-n/dZtw4G5J91mgi+OHZ8MpKkeFd5oRwIVZ8/Ju0BN+/LTcvj9lOPPDuCFBplS0lMBpcBYKn5eQxFuBpQv5t2lw==",
+      "peer": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "@typescript-eslint/utils": "^6.12.0",
     "typescript": "^5.3.2"
   },
+  "peerDependencies": {
+    "@figma/plugin-typings": "1.87.0"
+  },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.3",
     "@types/jest": "^29.5.11",


### PR DESCRIPTION
Some users are installing the ESLint plugin with out also adding `@figma/plugin-typings` to their project, which will just be confusing. This change adds `@figma/plugin-typings` as a peer dependency, which should provide a better error message for users in that situation.